### PR TITLE
fix(android_executor): add jvm memory opts to android executor enviornment

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -215,7 +215,8 @@ executors:
         default: '27'
     environment:
       FL_OUTPUT_DIR: output
-      _JAVA_OPTIONS: '-Xmx1500m'
+      _JAVA_OPTIONS: "-Xmx2048m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m"'
     docker:
       - image: circleci/android:api-<<parameters.version>>-node8-alpha
     working_directory: ~/react-native

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -215,8 +215,7 @@ executors:
         default: '27'
     environment:
       FL_OUTPUT_DIR: output
-      _JAVA_OPTIONS: "-Xmx2048m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m"'
+      _JAVA_OPTIONS: "-XX:MaxRAM=2048m -Xmx1024m"
     docker:
       - image: circleci/android:api-<<parameters.version>>-node8-alpha
     working_directory: ~/react-native


### PR DESCRIPTION
Found a reoccurring theme with RN setup for Android for avoiding OOM errors on CI.

Adding a few options to configure JVM on CI.
```
enviornment
    _JAVA_OPTIONS: "-Xmx2048m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m"'
```
Particularly of note is: `UseCGroupMemoryLimitForHeap` which seems like the main flag that helps keep JVM from killing itself by running out of memory.

Articles I found this information in:

https://medium.com/pink-room-club/android-continuous-integration-using-fastlane-and-circleci-2-0-part-ii-7f8dd7265659
https://blog.csanchez.org/2017/05/31/running-a-jvm-in-a-container-without-getting-killed/
https://medium.com/adorsys/jvm-memory-settings-in-a-container-environment-64b0840e1d9e

Unsure if all options I've included are necessary but with need to submit to Apple today, I decided to leave them be until there is more time to assess which are crucial to make these builds work (investment time).