### PR TITLE
refactor(xcode_version): downgrade the xcode version used on CI

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -224,7 +224,7 @@ executors:
     parameters:
       xcode_version:
         type: string
-        default: '10.2.0'
+        default: '10.1.0'
     macos:
       xcode: <<parameters.xcode_version>>
     working_directory: ~/react-native


### PR DESCRIPTION
Xcode 10.2 is causing all sorts of issues for builds at the moment. In particular it seems that 10.2 is a beta software and we are unable to upload binaries to the app store that are built with it. So build issues are necessarily the issue, but rather app submission when built with 10.2.

- Downgrading to 10.1