### PR TITLE
feat(executor_parameters): add resource_class and java_options as executor parameters

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -205,6 +205,8 @@ executors:
         type: string
         default: '8'
       resource_class:
+      # requires a support request to enable the resource_class parameter - default = medium
+      # https://circleci.com/docs/2.0/configuration-reference/#resource_class
         type: string
         default: medium
     docker:
@@ -218,6 +220,7 @@ executors:
         default: '27'
       java_options:
         type: string
+        # sets the min and max memory for builds
         default: '-Xms1048m -Xmx2048m'
       resource_class:
         type: string

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -204,33 +204,45 @@ executors:
       version:
         type: string
         default: '8'
+      resource_class:
+        type: string
+        default: medium
     docker:
       - image: circleci/node:<<parameters.version>>
     working_directory: ~/react-native
-
+    resource_class: <<parameters.resource_class>>
   android:
     parameters:
       version:
         type: string
         default: '27'
+      java_options:
+        type: string
+        default: '-Xms1048m -Xmx2048m'
+      resource_class:
+        type: string
+        default: medium
     environment:
       FL_OUTPUT_DIR: output
-      _JAVA_OPTIONS: "-XX:MaxRAM=2048m -Xmx1024m"
+      _JAVA_OPTIONS: <<parameters.java_options>>
     docker:
       - image: circleci/android:api-<<parameters.version>>-node8-alpha
     working_directory: ~/react-native
-
+    resource_class: <<parameters.resource_class>>
   ios:
     parameters:
       xcode_version:
         type: string
         default: '10.1.0'
+      resource_class:
+        type: string
+        default: medium
     macos:
       xcode: <<parameters.xcode_version>>
     working_directory: ~/react-native
     # use a --login shell so our "set Ruby version" command gets picked up for later steps
     shell: /bin/bash --login -o pipefail
-
+    resource_class: <<parameters.resource_class>>
 ################
 # Commands
 ################


### PR DESCRIPTION
Allows the project `circle.yml` to configure the `resource_class` for each executor individually, and the `JAVA_OPTIONS` (passed as `java_options`) parameter passed to the android build process.

Example:
```yaml
version: 2.1
orbs:
  react-native: echobind/react-native
workflows:
  version: 2
  main:
    jobs:
      - react-native/node:
          name: node
          ...
      - react-native/android:
          custom_executor:
            name: react-native/android
            java_options: '-Xms2080m -Xmx3072m'
            resource_class: medium+
...
```


Example use case: https://circleci.com/gh/truecoach/truecoach-connect/527